### PR TITLE
Implemented Request Filter,  blocks 'seen' receipts and typing indicators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 node_modules/
 npm-debug.log
 .env
+.idea

--- a/src/scripts/browser/menus/expressions/expr-click.js
+++ b/src/scripts/browser/menus/expressions/expr-click.js
@@ -2,6 +2,7 @@ import {app, shell} from 'electron';
 
 import * as piwik from 'browser/services/piwik';
 import prefs from 'browser/utils/prefs';
+import requestFilter from 'common/services/request-filter';
 
 /**
  * Call the handler for the check-for-update event.
@@ -246,6 +247,22 @@ export function hideTaskbarBadge (flagExpr) {
     const flag = flagExpr.apply(this, arguments);
     if (!flag) {
       browserWindow.setOverlayIcon(null, '');
+    }
+  };
+}
+
+/**
+ * Whether the user should appear as online and 'is typing' indicators be sent
+ */
+export function blockSeenTyping (flagExpr) {
+  return function (menuItem, browserWindow) {
+    const block = flagExpr.apply(this, arguments);
+    if (global.ready) {
+      if (block) {
+        requestFilter.enable();
+      } else {
+        requestFilter.disable();
+      }
     }
   };
 }

--- a/src/scripts/browser/menus/main.js
+++ b/src/scripts/browser/menus/main.js
@@ -7,6 +7,7 @@ export default function () {
     'browser/menus/templates/main-edit',
     'browser/menus/templates/main-view',
     'browser/menus/templates/main-theme',
+    'browser/menus/templates/main-privacy',
     'browser/menus/templates/main-window-darwin',
     'browser/menus/templates/main-window-nondarwin',
     'browser/menus/templates/main-help'

--- a/src/scripts/browser/menus/templates/main-privacy.js
+++ b/src/scripts/browser/menus/templates/main-privacy.js
@@ -1,0 +1,17 @@
+import $ from 'browser/menus/expressions';
+
+export default {
+  label: 'Privacy',
+  submenu: [{
+    id: 'block-seen-typing',
+    type: 'checkbox',
+    label: 'Block Seen and Typing Indicators',
+    click: $.all(
+        $.setPref('block-seen-typing', $.key('checked')),
+        $.blockSeenTyping($.key('checked'))
+    ),
+    parse: $.all(
+      $.setLocal('checked', $.pref('block-seen-typing'))
+    )
+  }]
+};

--- a/src/scripts/browser/utils/prefs-defaults.js
+++ b/src/scripts/browser/utils/prefs-defaults.js
@@ -11,6 +11,7 @@ const defaults = {
   'launch-startup-hidden': true,
   'launch-quit': false,
   'links-in-browser': true,
+  'block-seen-typing': false,
   'close-with-esc': false,
   'quit-behaviour-taught': false,
   'show-notifications-badge': true,

--- a/src/scripts/common/services/request-filter.js
+++ b/src/scripts/common/services/request-filter.js
@@ -1,37 +1,60 @@
 'use strict';
 
-const FILTER_URL_LIST = [
+
+/**
+ * URL match patterns to be filteresd
+ * @see https://developer.chrome.com/extensions/match_patterns
+ * @global
+ * @constant
+ */
+const urlPatternList = [
   '*://*.facebook.com/*change_read_status*',
   '*://*.messenger.com/*change_read_status*',
   '*://*.facebook.com/*typ.php*',
   '*://*.messenger.com/*typ.php*'
 ];
 
-let createFilter = () => {
-  return {urls: FILTER_URL_LIST};
-};
-
-let enableFilter = function () {
+/**
+ * Enable request cancelling of urls matched by pattern list
+ */
+let enableRequestFilter = () => {
   const targetSession = global.application.mainWindowManager.window.webContents.session;
-
-  targetSession.webRequest.onBeforeRequest(createFilter(), (details, callback) => {
+  targetSession.webRequest.onBeforeRequest({urls: urlPatternList}, (details, callback) => {
+    log(`request filter`, `blocked`, `${details.url}`);
     callback({cancel: true});
   });
 
-  log(`request filter enabled (entries: ${FILTER_URL_LIST.length})`);
+  log(`request filter`, `enabled`, `${urlPatternList.length} entries`);
 };
 
-let disableFilter = function () {
+/**
+ * Disable request cancelling of urls matched by pattern list
+ */
+let disableRequestFilter = () => {
   const targetSession = global.application.mainWindowManager.window.webContents.session;
+  targetSession.webRequest.onBeforeRequest({urls: urlPatternList}, null);
 
-  targetSession.webRequest.onBeforeRequest(createFilter(), (details, callback) => {
-    callback({cancel: false});
-  });
-
-  log('request filter disabled');
+  log(`request filter`, `disabled`);
 };
 
+/**
+ * Setter convenience interface
+ * @param {Boolean} enable - True/false to enable/disable filtering
+ */
+let setRequestFilter = (enable) => {
+  if (enable) {
+    enableRequestFilter();
+  } else {
+    disableRequestFilter();
+  }
+};
+
+
+/**
+ * @exports
+ */
 export default {
-  enable: enableFilter,
-  disable: disableFilter
+  enable: enableRequestFilter,
+  disable: disableRequestFilter,
+  set: setRequestFilter
 };

--- a/src/scripts/common/services/request-filter.js
+++ b/src/scripts/common/services/request-filter.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const FILTER_URL_LIST = [
+  '*://*.facebook.com/*change_read_status*',
+  '*://*.messenger.com/*change_read_status*',
+  '*://*.facebook.com/*typ.php*',
+  '*://*.messenger.com/*typ.php*'
+];
+
+let createFilter = () => {
+  return {urls: FILTER_URL_LIST};
+};
+
+let enableFilter = function () {
+  const targetSession = global.application.mainWindowManager.window.webContents.session;
+
+  targetSession.webRequest.onBeforeRequest(createFilter(), (details, callback) => {
+    callback({cancel: true});
+  });
+
+  log(`request filter enabled (entries: ${FILTER_URL_LIST.length})`);
+};
+
+let disableFilter = function () {
+  const targetSession = global.application.mainWindowManager.window.webContents.session;
+
+  targetSession.webRequest.onBeforeRequest(createFilter(), (details, callback) => {
+    callback({cancel: false});
+  });
+
+  log('request filter disabled');
+};
+
+export default {
+  enable: enableFilter,
+  disable: disableFilter
+};

--- a/src/scripts/common/services/request-filter.js
+++ b/src/scripts/common/services/request-filter.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 /**
  * URL match patterns to be filteresd
  * @see https://developer.chrome.com/extensions/match_patterns
@@ -20,11 +19,11 @@ const urlPatternList = [
 let enableRequestFilter = () => {
   const targetSession = global.application.mainWindowManager.window.webContents.session;
   targetSession.webRequest.onBeforeRequest({urls: urlPatternList}, (details, callback) => {
-    log(`request filter`, `blocked`, `${details.url}`);
+    log('request filter', 'blocked', details.url);
     callback({cancel: true});
   });
 
-  log(`request filter`, `enabled`, `${urlPatternList.length} entries`);
+  log('request filter', 'enabled', urlPatternList.length, 'entries');
 };
 
 /**
@@ -34,7 +33,7 @@ let disableRequestFilter = () => {
   const targetSession = global.application.mainWindowManager.window.webContents.session;
   targetSession.webRequest.onBeforeRequest({urls: urlPatternList}, null);
 
-  log(`request filter`, `disabled`);
+  log('request filter', 'disabled');
 };
 
 /**
@@ -48,7 +47,6 @@ let setRequestFilter = (enable) => {
     disableRequestFilter();
   }
 };
-
 
 /**
  * @exports


### PR DESCRIPTION
Hi @Aluxian 
Hi @Sytten

I re-implemented my NW.js-targetd 1.0 contribution for 2.0. 

It is implemented as a ``request-filter`` module (common -> service), which exports an object with ``enable()`` and ``disable()`` method. It's URL-agnostic, can be repurposed in the future (e.g., ad-blocking). It adds a new 'Privacy' main top-level menu.

It uses Electron's [WebRequest API](http://electron.atom.io/docs/api/web-request/), which has become stable. Code-style specs were applied as per ESLint configuration.

Closes #542.

Please review & comment, cheers, 
S