### PR TITLE
Update icon cache after installation

### DIFF
--- a/resources/linux/after-install.sh
+++ b/resources/linux/after-install.sh
@@ -2,3 +2,7 @@
 
 # Link to the binary
 ln -sf /opt/{{ name }}/{{ name }} /usr/bin/{{ name }}
+
+# Update icon cache
+/bin/touch --no-create /usr/share/icons/hicolor &>/dev/null
+/usr/bin/gtk-update-icon-cache /usr/share/icons/hicolor &>/dev/null || :


### PR DESCRIPTION
This will cause icons to work correctly immediately after installation
instead of requiring a user to log out and the back in.

See: https://fedoraproject.org/wiki/Packaging:Scriptlets#Icon_Cache