### PR TITLE
Add disable hardware acceleration to stop app using discreet graphics

### DIFF
--- a/src/scripts/browser/main.js
+++ b/src/scripts/browser/main.js
@@ -189,6 +189,8 @@ async function initAndLaunch () {
 
 async function onAppReady () {
   return await new Promise((resolve, reject) => {
+    app.disableHardwareAcceleration();
+    
     app.on('ready', () => {
       log('ready');
       resolve();


### PR DESCRIPTION
Disable hardware acceleration to ensure that application uses integrated graphics. Fixes #1172 and fixes #1163